### PR TITLE
fix(site): initialize certification modal lazily

### DIFF
--- a/src/assets/javascripts/scripts.js
+++ b/src/assets/javascripts/scripts.js
@@ -552,18 +552,36 @@
   // Certification Modal Handling
   const certificationModal = document.getElementById('certificationModal');
   const certificationItems = document.querySelectorAll('.certification-item');
-  const certificationModalInstance = certificationModal && window.bootstrap
-    ? new window.bootstrap.Modal(certificationModal)
-    : null;
 
-  if (certificationItems.length > 0 && certificationModalInstance) {
+  if (certificationItems.length > 0 && certificationModal) {
     const modalTitle = document.getElementById('modalTitle');
     const modalDescription = document.getElementById('modalDescription');
     const modalImage = document.getElementById('modalImage');
     const modalLink = document.getElementById('modalLink');
+    let certificationModalInstance = null;
+
+    const getCertificationModalInstance = () => {
+      if (certificationModalInstance) {
+        return certificationModalInstance;
+      }
+
+      if (!window.bootstrap?.Modal) {
+        return null;
+      }
+
+      certificationModalInstance = window.bootstrap.Modal.getOrCreateInstance(certificationModal);
+      return certificationModalInstance;
+    };
 
     certificationItems.forEach((item) => {
       item.addEventListener('click', () => {
+        const modalInstance = getCertificationModalInstance();
+
+        if (!modalInstance) {
+          console.error('Bootstrap Modal is not available for certification details.');
+          return;
+        }
+
         const title = item.dataset.title;
         const description = item.dataset.description;
         const validationUrl = item.dataset.validationUrl;
@@ -575,7 +593,7 @@
         modalImage.alt = title;
         modalLink.href = validationUrl;
 
-        certificationModalInstance.show();
+        modalInstance.show();
       });
     });
   }


### PR DESCRIPTION
## Summary
This pull request fixes the certification modal so it initializes reliably in production.

## Problem
The certification modal worked in local development but could fail on the published site because the page script tried to create the Bootstrap modal instance only once during module startup. If  was not available at that exact moment, the modal stayed unavailable for the rest of the session.

## Fix
The modal instance is now resolved lazily on click using .

## Impact
This keeps the certification modal working even when Bootstrap finishes loading after the main module has already executed.

## Validation
- Ran 
> githubpage@0.0.1 build /Users/tomas/Dev/tomtapia.github.io
> vite build

vite v7.3.1 building client environment for production...
transforming...
✓ 8 modules transformed.
rendering chunks...
computing gzip size...
../dist/privacy.html                                           6.52 kB │ gzip: 2.52 kB
../dist/assets/1618927928114-C6FkdNQX.webp                     9.15 kB
../dist/assets/1618927965177-ClcZ05aN.webp                     9.41 kB
../dist/assets/1618927730910-BvtLkdWT.webp                     9.52 kB
../dist/assets/AWS_CQ_SA-VPlP_Iqx.webp                        10.35 kB
../dist/assets/AWS_CQ_CP-BSZ_GGr4.webp                        12.28 kB
../dist/assets/Deploy_Kubernetes_Google_Cloud-CgludhYM.webp   13.74 kB
../dist/assets/Serverless_Firebase_Development-DOOUo9DG.webp  15.10 kB
../dist/assets/AWS_SAAC-De5kbsS7.webp                         15.70 kB
../dist/assets/Me_Simple-CqgJavuI.webp                        28.37 kB
../dist/index.html                                            32.01 kB │ gzip: 8.07 kB
../dist/assets/AWS_GenAIFC-DBXHuqQN.webp                      34.10 kB
../dist/assets/favicon-CK6kBCCl.ico                           36.95 kB
../dist/assets/GCP_CDLC-BkYl9BSF.webp                         37.12 kB
../dist/assets/Coursera_CUH8FD9ECCV4-BwsPqeFC.webp            63.76 kB
../dist/assets/Coursera_W5489Z5VJRHZ-BoIxUJyK.webp            63.94 kB
../dist/assets/Coursera_YZJET5UN78F5-C_6vwrE_.webp            64.06 kB
../dist/assets/Coursera_826QY98D69EP-BVF_aQnQ.webp            64.40 kB
../dist/assets/Coursera_JBXXQVNEW47R-DvLV4OhX.webp            64.56 kB
../dist/assets/Coursera_P3S5ZQMYSXBG-BulSmM44.webp            64.59 kB
../dist/assets/Coursera_SRDWVAHWTV65-BA5z211f.webp            64.61 kB
../dist/assets/Coursera_MWAKYZ5F8HU8-C3Vk8Atu.webp            66.34 kB
../dist/assets/style-DXA91v0K.css                             19.26 kB │ gzip: 4.20 kB
../dist/assets/style-DG_xwqVJ.js                               0.71 kB │ gzip: 0.40 kB
../dist/assets/index-BtcGRbM9.js                              21.48 kB │ gzip: 5.80 kB
✓ built in 222ms
- Confirmed the change is isolated to 