### PR TITLE
fix(security): harden Vite localhost defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ pnpm start
 ```
 
 ## Development Security Notes
-- The Vite dev server and preview server are intentionally bound to `127.0.0.1`.
+- The Vite dev server and preview server are intentionally bound to 127.0.0.1.
 - Do not expose Vite to LAN or the public internet unless that change is explicitly required and risk-reviewed first.
-- Security hotfixes for Vite are tracked in issue `#18`, with the dependency upgrade handled in PR `#17`.
 
 ## Contribution
 To contribute to this project, please send a pull request or open an issue.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ pnpm install
 pnpm start
 ```
 
+## Development Security Notes
+- The Vite dev server and preview server are intentionally bound to `127.0.0.1`.
+- Do not expose Vite to LAN or the public internet unless that change is explicitly required and risk-reviewed first.
+- Security hotfixes for Vite are tracked in issue `#18`, with the dependency upgrade handled in PR `#17`.
+
 ## Contribution
 To contribute to this project, please send a pull request or open an issue.
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,6 +5,16 @@ import { createHtmlPlugin } from 'vite-plugin-html';
 export default defineConfig({
   root: 'src',
   publicDir: 'public',
+  server: {
+    host: '127.0.0.1',
+    port: 8080,
+    strictPort: true,
+  },
+  preview: {
+    host: '127.0.0.1',
+    port: 4173,
+    strictPort: true,
+  },
   plugins: [
     createHtmlPlugin({
       minify: true,


### PR DESCRIPTION
## Summary
- make Vite dev and preview host binding explicit in `vite.config.js`
- keep localhost-only defaults on `127.0.0.1` with strict ports
- document the local-only policy and relate this work to the Vite security remediation

## Context
This PR complements the dependency hotfix in #17. It keeps the hardening work isolated in a human-owned branch while the Vite version bump remains in the Dependabot PR.

Closes #18

## Verification
- `pnpm build`
- `pnpm start`
- manual smoke check of `/` and `/privacy.html`
